### PR TITLE
Update Tax module to reflect API changes and deprecations

### DIFF
--- a/docs/openapi-wrapper.md
+++ b/docs/openapi-wrapper.md
@@ -98,7 +98,8 @@ This list captures the currently implemented endpoints and their wrapper methods
 - `POST /shipping/rates` -> `client.shipping.calculate(body)`
 
 ### Tax Rate API
-- `POST /tax/rates` -> `client.tax.getRate(body)`
+- `GET /tax/countries` -> `client.tax.getCountries()`
+- **Omitted (deprecated):** `POST /tax/rates` (Calculate tax rate). Printful deprecated this endpoint (sunset process started July 2025; no replacement in the API). For details and migration guidance, see [Tax Rate API – Calculate tax rate](https://developers.printful.com/docs/#tag/Tax-Rate-API/operation/calculateTaxRates).
 
 ## Query Params Reference (v1)
 
@@ -122,6 +123,14 @@ When extending the wrapper with new v1 endpoints:
 5. Update this document:
    - Add the endpoint under the matching section.
    - Update the tag mapping if a new module is created.
+
+## Deprecated / Omitted Endpoints (v1)
+
+Endpoints that exist in the Printful v1 API but are **not** implemented in this wrapper because they are deprecated or sunset:
+
+| Endpoint | Reason | Reference |
+| --- | --- | --- |
+| `POST /tax/rates` (Calculate tax rate) | Deprecated by Printful; sunset process started July 2025; no replacement in the Printful API. Use order creation/estimation for costs including tax, or external tax providers. | [Tax Rate API – Calculate tax rate](https://developers.printful.com/docs/#tag/Tax-Rate-API/operation/calculateTaxRates) |
 
 ## Notes for v2
 

--- a/docs/openapi-wrapper.md
+++ b/docs/openapi-wrapper.md
@@ -99,7 +99,7 @@ This list captures the currently implemented endpoints and their wrapper methods
 
 ### Tax Rate API
 - `GET /tax/countries` -> `client.tax.getCountries()`
-- **Omitted (deprecated):** `POST /tax/rates` (Calculate tax rate). Printful deprecated this endpoint (sunset process started July 2025; no replacement in the API). For details and migration guidance, see [Tax Rate API – Calculate tax rate](https://developers.printful.com/docs/#tag/Tax-Rate-API/operation/calculateTaxRates).
+- **Omitted (deprecated):** `POST /tax/rates` On July 29, 2025, we started the sunset process. The rate limit is being reduced by 10 RPM each week (starting with 60) until it reaches 0 on September 8, 2025, at which point the endpoint will be removed entirely. [Tax Rate API – Calculate tax rate](https://developers.printful.com/docs/#tag/Tax-Rate-API/operation/calculateTaxRates).
 
 ## Query Params Reference (v1)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "printful-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Printful API Wrapper in TypeScript",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "printful-client",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Printful API Wrapper in TypeScript",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/modules/Tax.ts
+++ b/src/modules/Tax.ts
@@ -1,32 +1,22 @@
 /**
- * Printfull Tax Calculator
+ * Printfull Tax API
  */
 
 import { BaseModule } from "./BaseModule";
 import { RequestHelper } from "../RequestHelper";
 
-type TaxRequest = {
-  recipient: {
-    country_code: string;
-    state_code: string;
-    city: string;
-    zip: string;
-  };
-};
 class Tax extends BaseModule {
   constructor(requestHelper: RequestHelper) {
     super(requestHelper);
   }
 
   /**
-   * Get Tax Rate
-   * @param taxRequest Get tax rate request
-   * @returns Response Object with tax rate information
+   * Get a list of countries for tax calculation
+   * @returns Response Object with tax countries
    */
-  getRate(taxRequest: TaxRequest) {
-    return this._execute(`/tax/rates`, {
-      body: JSON.stringify(taxRequest),
-      method: "Post",
+  public getCountries(): Promise<Response> {
+    return this._execute(`/tax/countries`, {
+      method: "Get",
     });
   }
 }

--- a/src/modules/Tax.ts
+++ b/src/modules/Tax.ts
@@ -16,7 +16,7 @@ class Tax extends BaseModule {
    */
   public getCountries(): Promise<Response> {
     return this._execute(`/tax/countries`, {
-      method: "Get",
+      method: "GET",
     });
   }
 }


### PR DESCRIPTION
- Replaced `getRate` method with `getCountries` to align with the new Tax API.
- Documented the deprecation of the `POST /tax/rates` endpoint, including migration guidance.
- Added a new section for deprecated endpoints in the documentation for clarity.

## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.
- Don't forget a changeset! `pnpm exec changeset`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Is this a visible change? You probably need to update docs! -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new tax-related endpoint to retrieve country data (exposed as getCountries()).

* **Documentation**
  * Updated API docs to reflect the tax endpoint change and added a “Deprecated / Omitted Endpoints (v1)” section.

* **Deprecation**
  * Previous tax rate endpoint marked deprecated and scheduled for sunset (see docs for details).

* **Version**
  * Release bumped to v0.2.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->